### PR TITLE
Issue2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ cd check-your-pulse
 
 ```HTML
 Download the logs from web console
-Download your logs
 ```
 
 Instructions can be found

--- a/app.py
+++ b/app.py
@@ -333,7 +333,9 @@ def _summary(
                 ]
             )
 
-        conn_list = sorted(conn_list, key=lambda x: x[0])
+        conn_list = sorted(
+            conn_list, key=lambda x: x[0] if x else datetime.datetime.now()
+        )
 
         for item in conn_list[0:numevents]:
             summary_output += "\n" + item[2]

--- a/app.py
+++ b/app.py
@@ -310,8 +310,8 @@ def _summary(
 
         conn_list = [
             (
-                conn.date_time,
-                conn.UID,
+                conn._date_time,
+                conn._UID,
                 f"Log: {conn.type}\tInfo: {Color._green(conn.user)} was connected from {Color._green(conn.begin_time)}"
                 f"to {Color._green(conn.end_time)} from {Color._green(conn.ip)}",
             )


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

Changed sorting of our connections to fix datetime.datetime and NoneType comparison issue.

## 🗣 Description

<!--- Describe your changes in detail -->

changed
```python
        conn_list = sorted(
            conn_list, key=lambda x: x[0] 
        )
```

to
```python
        conn_list = sorted(
            conn_list, key=lambda x: x[0] if x else datetime.datetime.now()
        )
```
this should provide sorted() a current datetime object for the purposes of sorting when a connection does not have a _date_time property. This effectively moves these odd connections to the top of our list.

## 💭 Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Solves an issue where datetime.datetime objects were being compared to None.

<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/cisagov/check-your-pulse/issues/2

## 🧪 Testing

<!--- Please describe in detail how you tested your changes. -->

Tested on a test set of logs and ran pre-commit tests.

<!--- Include details of your testing environment, and the tests you ran to -->

MacOS Mojave, Python 3.7, PyCharm

<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
